### PR TITLE
Do not use production for NODE_ENV

### DIFF
--- a/gateway/fly.toml
+++ b/gateway/fly.toml
@@ -8,7 +8,7 @@ processes = []
 
 [env]
   APOLLO_GRAPH_REF = "industry-vertical-retail@prod"
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]

--- a/subgraphs/inventory/fly.toml
+++ b/subgraphs/inventory/fly.toml
@@ -7,7 +7,7 @@ processes = []
   builder = "heroku/buildpacks:20"
 
 [env]
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]

--- a/subgraphs/orders/fly.toml
+++ b/subgraphs/orders/fly.toml
@@ -7,7 +7,7 @@ processes = []
   builder = "heroku/buildpacks:20"
 
 [env]
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]

--- a/subgraphs/products/fly.toml
+++ b/subgraphs/products/fly.toml
@@ -7,7 +7,7 @@ processes = []
   builder = "heroku/buildpacks:20"
 
 [env]
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]

--- a/subgraphs/shipping/fly.toml
+++ b/subgraphs/shipping/fly.toml
@@ -7,7 +7,7 @@ processes = []
   builder = "heroku/buildpacks:20"
 
 [env]
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]

--- a/subgraphs/users/fly.toml
+++ b/subgraphs/users/fly.toml
@@ -7,7 +7,7 @@ processes = []
   builder = "heroku/buildpacks:20"
 
 [env]
-  NODE_ENV = "production"
+  NODE_ENV = "fly"
   PORT = "8080"
 
 [experimental]


### PR DESCRIPTION
Using `production` as the NODE_ENV disables introspection and other features that we want to keep on for our environment